### PR TITLE
feat: add typing indicators for AI personas

### DIFF
--- a/client/src/components/ChatRoom.jsx
+++ b/client/src/components/ChatRoom.jsx
@@ -2,9 +2,10 @@
 import { useEffect, useRef, useState } from "react";
 import { useSocket } from "../hooks/useSocket";
 import MessageBubble from "./MessageBubble";
+import TypingIndicators from "./TypingIndicators";
 
 export default function ChatRoom({ username }) {
-  const { messages, connected, sendMessage } = useSocket(username);
+  const { messages, connected, sendMessage, typingUsers } = useSocket(username);
   const [input, setInput] = useState("");
   const bottomRef = useRef(null);
 
@@ -74,6 +75,9 @@ export default function ChatRoom({ username }) {
         {/* Invisible div at bottom for auto-scroll */}
         <div ref={bottomRef} />
       </div>
+
+      {/* Typing indicators  */}
+      <TypingIndicators typingUsers={typingUsers} />
 
       {/* Input Area */}
       <div className="bg-white border-t border-gray-200 px-4 py-3 flex items-center gap-2">

--- a/client/src/components/JoinScreen.jsx
+++ b/client/src/components/JoinScreen.jsx
@@ -10,7 +10,7 @@ export default function JoinScreen ({onJoin}) {
     }
 
     function handleKeyDown (e) {
-        if (e.Key === 'Enter') handleSubmit();
+        if (e.key === 'Enter') handleSubmit();
     }
 
     return (

--- a/client/src/components/TypingIndicators.jsx
+++ b/client/src/components/TypingIndicators.jsx
@@ -1,0 +1,40 @@
+
+
+export default function TypingIndicators ({ typingUsers}) {
+    if (!typingUsers || typingUsers.length === 0) return null;
+
+return (
+    <div className="px-4 py-2 space-y-2">
+      {typingUsers.map((persona) => (
+        <div key={persona.name} className="flex items-center gap-2">
+
+          {/* Persona avatar */}
+          <div
+            className="w-8 h-8 rounded-full flex items-center justify-center text-sm flex-shrink-0"
+            style={{ backgroundColor: persona.color + "22" }}
+          >
+            {persona.avatar}
+          </div>
+
+          {/* Typing bubble */}
+          <div className="bg-white border border-gray-200 rounded-2xl rounded-tl-sm px-4 py-2 shadow-sm">
+            <div className="flex items-center gap-1">
+              <span
+                className="text-xs font-semibold mr-2"
+                style={{ color: persona.color }}
+              >
+                {persona.name}
+              </span>
+
+              {/* Animated dots */}
+              <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]" />
+              <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]" />
+              <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]" />
+            </div>
+          </div>
+
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/hooks/useSocket.js
+++ b/client/src/hooks/useSocket.js
@@ -6,6 +6,7 @@ const SERVER_URL = import.meta.env.VITE_SERVER_URL || "http://localhost:3001";
 export function useSocket(username) {
   const [messages, setMessages] = useState([]);
   const [connected, setConnected] = useState(false);
+  const [typingUsers, setTypingUsers] = useState([]);
   const socketRef = useRef(null);
 
   useEffect(() => {
@@ -33,6 +34,21 @@ export function useSocket(username) {
       setMessages((prev) => [...prev, message]);
     });
 
+    //Add persona to typing list
+    socket.on ("typing_start", (persona) => {
+      setTypingUsers ((prev) => {
+        const list = prev || [];
+        const already = list.find((p) => p.name === persona.name);
+        if (already) return list;
+        return [...list, persona]
+      });
+    });
+
+    //Remove the persona from the typing list array
+    socket.on("typing_stop", ({ name }) => {
+     setTypingUsers((prev) => (prev || []).filter((p) => p.name !== name));
+    });
+
     return () => {
       socket.disconnect();
     };
@@ -43,5 +59,5 @@ export function useSocket(username) {
     socketRef.current.emit("user_message", { username, text });
   }
 
-  return { messages, connected, sendMessage };
+  return { messages, connected, sendMessage, typingUsers };
 }

--- a/server/index.js
+++ b/server/index.js
@@ -113,12 +113,17 @@ io.on("connection", (socket) => {
         reacting.forEach((persona, i) => {
           setTimeout(async () => {
             try {
+              //persona has started typing
+              io.emit ("typing_start", { name: persona.name, avatar: persona.avatar, color: persona.color});
+
               const reactionText = await getPersonaResponse(persona, chatHistory);
               await emitMessage(persona, reactionText, i + 1);
+              io.emit ("typing_stop", { name: persona.name}); //persona stopped typing
+
             } catch (err) {
               console.error(`${persona.name} welcome reaction error:`, err.message);
             }
-          }, randomDelay(5000, 10000) + i * randomDelay(2000, 4000));
+          }, randomDelay(8000, 12000) + i * randomDelay(3000, 5000));
         });
 
       } catch (err) {
@@ -148,12 +153,20 @@ io.on("connection", (socket) => {
     }
 
     responding.forEach((persona, i) => {
-      const delay = randomDelay(4000, 12000) + i * randomDelay(2000, 4000);
+      const delay = randomDelay(7000, 17000) + i * randomDelay(3000, 5000);
 
       setTimeout(async () => {
         try {
+          //Tell the app that this person is typing.
+          io.emit ("typing_start", { name: persona.name, avatar: persona.avatar, color: persona.color});
+
           const responseText = await getPersonaResponse(persona, chatHistory);
           await emitMessage(persona, responseText, i);
+
+          //Tell the app that this person has stopped typing.
+          io.emit ("typing_stop", { name: persona.name});
+
+
         } catch (err) {
           console.error(`${persona.name} error:`, err.message);
         }


### PR DESCRIPTION
## What this PR does
- Adds typing indicators showing which persona is generating a response
- Server emits typing_start and typing_stop events around Groq API calls
- Frontend displays animated bouncing dots with persona avatar and name
- Multiple personas can show as typing simultaneously
- Dots disappear exactly when the message arrives

## Files changed
- server/index.js — emit typing events
- client/src/hooks/useSocket.js — listen for typing events
- client/src/components/TypingIndicators.jsx — new component
- client/src/components/ChatRoom.jsx — wire TypingIndicators in
- client/src/components/JoinScreen.jsx — fix Enter key capitalisation